### PR TITLE
refactor: Remove chip padding from config and add gap between chips

### DIFF
--- a/config.js
+++ b/config.js
@@ -40,11 +40,7 @@ const CONFIG = {
     BADGE_SPACING: 30,           // Отступ между бейджами
     POSITION_FONT_SIZE: 40,      // Размер шрифта должности
     NAME_FONT_SIZE: 40,          // Размер шрифта ФИО
-    RESPONSIBILITY_FONT_SIZE: 40, // Размер шрифта зон ответственности
-    
-    // Отступы в чипсах
-    CHIP_PADDING_VERTICAL: 36,   // Отступ сверху/снизу в чипсах
-    CHIP_PADDING_HORIZONTAL: 48  // Отступ по бокам в чипсах
+    RESPONSIBILITY_FONT_SIZE: 40 // Размер шрифта зон ответственности
 };
 
 // Экспортируем конфигурацию

--- a/style.css
+++ b/style.css
@@ -2,8 +2,6 @@
     --primary-color: #0037C0;
     --warning-color: #FF9800;
     --overdue-color: #f44336;
-    --chip-padding-vertical: 36px;
-    --chip-padding-horizontal: 48px;
 }
 
 @font-face {
@@ -207,7 +205,7 @@ body {
 /* Стили для информации о сотруднике */
 .employee-info {
     display: flex;
-    gap: 0;
+    gap: 12px; /* Отступ между PM и ФИО */
     margin-top: 30px;
     align-items: center;
 }
@@ -218,7 +216,7 @@ body {
     font-family: 'Stolzl', sans-serif;
     font-weight: 500;
     font-size: 40px;
-    padding: var(--chip-padding-vertical, 36px) var(--chip-padding-horizontal, 48px);
+    padding: 36px 48px; /* 36px сверху/снизу, 48px по бокам */
     border-radius: 60px 24px 24px 60px; /* 60px слева, 24px справа */
     white-space: nowrap;
     display: flex;
@@ -233,7 +231,7 @@ body {
     font-family: 'Stolzl', sans-serif;
     font-weight: 500;
     font-size: 40px;
-    padding: var(--chip-padding-vertical, 36px) var(--chip-padding-horizontal, 48px);
+    padding: 36px 48px; /* 36px сверху/снизу, 48px по бокам */
     border-radius: 24px 60px 60px 24px; /* 24px слева, 60px справа */
     white-space: nowrap;
     display: flex;


### PR DESCRIPTION
- Remove CHIP_PADDING_VERTICAL and CHIP_PADDING_HORIZONTAL from config.js
- Remove CSS variables for chip padding
- Add 12px gap between position and name chips
- Use fixed padding values in CSS instead of config variables

Changes:
- .employee-info gap: 12px between PM and name chips
- Removed config variables for chip padding
- Simplified CSS by removing unused variables